### PR TITLE
Tooltip: increase show delay

### DIFF
--- a/tidy-at-rule.js
+++ b/tidy-at-rule.js
@@ -1,0 +1,9 @@
+function tidyAtRule(value) {
+  return value
+    .replace(/\s+/g, ' ')
+    .replace(/url\(\s+/g, 'url(')
+    .replace(/\s+\)/g, ')')
+    .trim();
+}
+
+module.exports = tidyAtRule;


### PR DESCRIPTION
Increase tooltip show delay from 100ms to 200ms to reduce flicker on quick mouse movements. Updates Tooltip component default props and adds unit tests to cover timing.