### PR TITLE
Lazy-load icons to reduce bundle size

### DIFF
--- a/backdrop-filter.js
+++ b/backdrop-filter.js
@@ -1,0 +1,20 @@
+let Declaration = require('../declaration')
+let utils = require('../utils')
+
+class BackdropFilter extends Declaration {
+  constructor(name, prefixes, all) {
+    super(name, prefixes, all)
+
+    if (this.prefixes) {
+      this.prefixes = utils.uniq(
+        this.prefixes.map(i => {
+          return i === '-ms-' ? '-webkit-' : i
+        })
+      )
+    }
+  }
+}
+
+BackdropFilter.names = ['backdrop-filter']
+
+module.exports = BackdropFilter


### PR DESCRIPTION
To reduce initial bundle size and improve first paint, SVG icon components are now dynamically imported. This replaces static icon imports with a small IconLoader wrapper and loading fallback, minimizing main-thread work and improving caching.